### PR TITLE
Now prints errors instead of silently ignoring them

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,8 @@ func main() {
 					fmt.Println(result.Addresses[i].StringFormatted())
 				}
 			}
+		} else {
+			print_error(err)
 		}
 	case "city":
 		result, err := cityQuery(arguments.Args["zip"])
@@ -111,6 +113,8 @@ func main() {
 					fmt.Println(result.NonAccept[i])
 				}
 			}
+		} else {
+			print_error(err)
 		}
 	case "zip":
 		result, err := zipQuery(arguments.Args["city"], arguments.Args["state"])
@@ -123,6 +127,12 @@ func main() {
 					fmt.Println(result.Zips[i])
 				}
 			}
+		} else {
+			print_error(err)
 		}
 	}
+}
+
+func print_error(err error) {
+	fmt.Printf("\033[91;1m%s\033[0m\n", err)
 }

--- a/send_request.go
+++ b/send_request.go
@@ -79,7 +79,7 @@ func addHeaders(req *http.Request, referer string) {
 func checkResult[Result ZipQueryResult | AddressQueryResult | CityQueryResult](response *http.Response, err error) (*Result, error) {
 	var result Result
 	if err != nil {
-		return &result, errors.New(fmt.Sprintf("Error sending request: %s", err))
+		return &result, err
 	}
 	defer response.Body.Close()
 	if response.StatusCode != 200 {


### PR DESCRIPTION
Closes #1 .
Each sub-command will now print out any errors it receives.